### PR TITLE
Fix show_backups command

### DIFF
--- a/twins-deploy/twins-deploy-ctl
+++ b/twins-deploy/twins-deploy-ctl
@@ -128,7 +128,7 @@ show_backups() {
     
     local backup_dir="/opt/twins-deploy/backups"
     if [ -d "$backup_dir" ]; then
-        ls -la "$backup_dir" | grep "^d" | awk {print , , , } | grep -v "^\.$\|^\.\.$" | while read backup date1 date2 time; do
+        ls -la "$backup_dir" | grep "^d" | awk '{print $9,$6,$7,$8}' | grep -v '^\.\.\? ' | while read backup date1 date2 time; do
             if [ -n "$backup" ]; then
                 echo -e "  📦 ${GREEN}$backup${NC} - $date1 $date2 $time"
             fi


### PR DESCRIPTION
## Summary
- update the `awk` command in `show_backups` so backup directories and dates are listed correctly

## Testing
- `bash twins-deploy/twins-deploy-ctl backups`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860378b244483279759d03a46045ed0