### PR TITLE
Improve explorer styling

### DIFF
--- a/twins-explorer/src/app/block/[id]/page.tsx
+++ b/twins-explorer/src/app/block/[id]/page.tsx
@@ -42,7 +42,7 @@ export default function BlockPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="bg-white rounded-lg shadow p-6">
+      <div className="card">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Block {block.height.toLocaleString()}</h1>
@@ -70,7 +70,7 @@ export default function BlockPage() {
       </div>
 
       {/* Block Details */}
-      <div className="bg-white rounded-lg shadow">
+      <div className="card p-0">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900">Block Information</h2>
         </div>
@@ -161,7 +161,7 @@ export default function BlockPage() {
       </div>
 
       {/* Transactions */}
-      <div className="bg-white rounded-lg shadow">
+      <div className="card p-0">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900">
             Transactions ({block.nTx})

--- a/twins-explorer/src/app/globals.css
+++ b/twins-explorer/src/app/globals.css
@@ -1,15 +1,17 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fafafa;
+  --foreground: #111111;
+  --accent: #2563eb;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-accent: var(--accent);
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, "Liberation Mono", "Courier New", monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -20,7 +22,25 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans), sans-serif;
+}
+
+@layer base {
+  h1 {
+    @apply text-3xl font-semibold tracking-tight;
+  }
+  h2 {
+    @apply text-2xl font-semibold tracking-tight;
+  }
+  h3 {
+    @apply text-xl font-semibold tracking-tight;
+  }
+}
+
+@layer components {
+  .card {
+    @apply bg-white/80 backdrop-blur border border-gray-200 rounded-lg p-6;
+  }
 }

--- a/twins-explorer/src/app/layout.tsx
+++ b/twins-explorer/src/app/layout.tsx
@@ -1,19 +1,8 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
 import NodeStatus from "@/components/NodeStatus";
 import AuthWrapper from "@/components/AuthWrapper";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "TWINS Blockchain Explorer",
@@ -27,18 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
-      >
+      <body className="antialiased bg-[color:var(--color-background)]">
         <AuthWrapper>
-          <div className="min-h-screen">
+          <div className="min-h-screen flex flex-col">
             {/* Navigation Header */}
-            <nav className="bg-white shadow-sm border-b">
+            <nav className="fixed inset-x-0 top-0 z-50 bg-white/80 backdrop-blur border-b border-gray-200">
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex justify-between h-16">
                   <div className="flex items-center">
                     <Link href="/" className="flex-shrink-0 flex items-center">
-                      <div className="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center">
+                      <div className="h-8 w-8 bg-[color:var(--color-accent)] rounded-lg flex items-center justify-center">
                         <span className="text-white font-bold text-sm">T</span>
                       </div>
                       <span className="ml-2 text-xl font-bold text-gray-900">TWINS Explorer</span>
@@ -76,12 +63,12 @@ export default function RootLayout({
             </nav>
 
             {/* Main Content */}
-            <main className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <main className="flex-grow max-w-7xl mx-auto pt-20 px-4 sm:px-6 lg:px-8">
               {children}
             </main>
 
             {/* Footer */}
-            <footer className="bg-white border-t mt-12">
+            <footer className="bg-white/80 backdrop-blur border-t border-gray-200 mt-12">
               <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">

--- a/twins-explorer/src/app/page.tsx
+++ b/twins-explorer/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
   return (
     <div className="space-y-8">
       {/* Search Bar */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-bold text-gray-900">Search the TWINS Blockchain</h2>
           <div className="flex items-center space-x-2">
@@ -59,7 +59,7 @@ export default function HomePage() {
       </div>
 
       {/* Network Status Overview */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <h2 className="text-2xl font-bold text-gray-900 mb-6">TWINS Network Status</h2>
         {status ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -86,7 +86,7 @@ export default function HomePage() {
       </div>
 
       {/* Recent Blocks */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold text-gray-900">Recent Blocks</h2>
           <Link 
@@ -144,7 +144,7 @@ export default function HomePage() {
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <h2 className="text-2xl font-bold text-gray-900 mb-6">Explorer Features</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Link href="/stats" className="p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">

--- a/twins-explorer/src/app/stats/page.tsx
+++ b/twins-explorer/src/app/stats/page.tsx
@@ -40,7 +40,7 @@ export default function StatsPage() {
   return (
     <div className="space-y-8">
       {/* Page Header */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold text-gray-900">TWINS Network Statistics</h1>
@@ -64,7 +64,7 @@ export default function StatsPage() {
 
       {/* Core Network Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <div className="flex items-center">
             <div className="flex-shrink-0">
               <div className="w-8 h-8 bg-blue-100 rounded-md flex items-center justify-center">
@@ -80,7 +80,7 @@ export default function StatsPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <div className="flex items-center">
             <div className="flex-shrink-0">
               <div className={`w-8 h-8 rounded-md flex items-center justify-center ${
@@ -112,7 +112,7 @@ export default function StatsPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <div className="flex items-center">
             <div className="flex-shrink-0">
               <div className="w-8 h-8 bg-purple-100 rounded-md flex items-center justify-center">
@@ -128,7 +128,7 @@ export default function StatsPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <div className="flex items-center">
             <div className="flex-shrink-0">
               <div className="w-8 h-8 bg-orange-100 rounded-md flex items-center justify-center">
@@ -150,7 +150,7 @@ export default function StatsPage() {
       {/* Additional Statistics */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Block Statistics */}
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <h2 className="text-xl font-bold text-gray-900 mb-4">Block Statistics</h2>
           <div className="space-y-4">
             <div className="flex justify-between items-center">
@@ -182,7 +182,7 @@ export default function StatsPage() {
         </div>
 
         {/* Version Information */}
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <h2 className="text-xl font-bold text-gray-900 mb-4">Node Information</h2>
           <div className="space-y-4">
             <div className="flex justify-between items-center">
@@ -211,7 +211,7 @@ export default function StatsPage() {
 
       {/* Sporks Information */}
       {sporks.length > 0 && (
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <div className="card">
           <h2 className="text-xl font-bold text-gray-900 mb-4">Network Sporks</h2>
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
@@ -261,7 +261,7 @@ export default function StatsPage() {
       )}
 
       {/* Recent Blocks Summary */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-bold text-gray-900">Recent Block Activity</h2>
           <Link 

--- a/twins-explorer/src/app/tx/[txid]/page.tsx
+++ b/twins-explorer/src/app/tx/[txid]/page.tsx
@@ -42,7 +42,7 @@ export default function TransactionPage() {
   return (
     <div className="space-y-6">
       {/* Transaction Header */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold text-gray-900">Transaction Details</h1>
           <div className="flex space-x-2">
@@ -111,7 +111,7 @@ export default function TransactionPage() {
       </div>
 
       {/* Transaction Inputs */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <h2 className="text-xl font-bold text-gray-900 mb-4">
           Inputs ({transaction.vin.length})
         </h2>
@@ -153,7 +153,7 @@ export default function TransactionPage() {
       </div>
 
       {/* Transaction Outputs */}
-      <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="card">
         <h2 className="text-xl font-bold text-gray-900 mb-4">
           Outputs ({transaction.vout.length})
         </h2>


### PR DESCRIPTION
## Summary
- refine overall explorer styling for a cleaner look
- implement simplified header and footer
- add global `card` component class
- switch to system fonts so build does not require downloads

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860394159748327b1bedd0179dd5ebf