### PR TITLE
Add node sync reset endpoint and UI control

### DIFF
--- a/TWINS-Core/twins_node_rust/src/api_service.rs
+++ b/TWINS-Core/twins_node_rust/src/api_service.rs
@@ -1,6 +1,6 @@
 use axum;
 use axum::{
-    routing::get,
+    routing::{get, post},
     response::{Json, IntoResponse, Response, Sse},
     Router,
     extract::{State, Path, Query},
@@ -438,6 +438,12 @@ struct HybridSyncResponse {
     mode_description: String,
 }
 
+#[derive(Serialize)]
+struct ResetSyncResponse {
+    success: bool,
+    message: String,
+}
+
 async fn hybrid_sync_handler(State(app_state): State<ApiAppState>) -> Json<HybridSyncResponse> {
     log::info!("API /hybrid-sync endpoint called");
     
@@ -822,8 +828,16 @@ async fn get_peers_handler(
     
     // Since we don't have direct access to peer details yet, return basic info
     let peers_info = vec![]; // Placeholder - would need PeerManager enhancement
-    
+
     Ok(Json(peers_info))
+}
+
+async fn reset_sync_handler(
+    State(app_state): State<ApiAppState>,
+) -> Json<ResetSyncResponse> {
+    log::info!("API /reset-sync endpoint called");
+    app_state.chain_state.reset();
+    Json(ResetSyncResponse { success: true, message: "Sync reset".to_string() })
 }
 
 async fn status_stream_handler(
@@ -897,6 +911,7 @@ pub fn create_router(app_state: ApiAppState) -> Router {
         .route("/api/v1/masternode/:outpoint", get(get_masternode_detail_handler))
         .route("/api/v1/governance/proposals", get(get_governance_proposals_handler))
         .route("/api/v1/peers", get(get_peers_handler))
+        .route("/api/v1/reset-sync", post(reset_sync_handler))
         .route("/api/v1/status/stream", get(status_stream_handler))
         .route("/api/v1/torrent-sync", get(torrent_sync_handler))
         .route("/api/v1/hybrid-sync", get(hybrid_sync_handler))

--- a/twins-explorer/src/app/node/page.tsx
+++ b/twins-explorer/src/app/node/page.tsx
@@ -1,6 +1,28 @@
+"use client";
+
+import { useState } from 'react';
 import NodeStatus from '@/components/NodeStatus';
 
+async function resetSync() {
+  const confirmed = window.confirm(
+    'Resetting sync will delete all local blocks and restart the sync process. Continue?' 
+  );
+  if (!confirmed) return;
+
+  await fetch('/api/v1/reset-sync', { method: 'POST' });
+}
+
 export default function NodeStatusPage() {
+  const [resetting, setResetting] = useState(false);
+
+  const handleReset = async () => {
+    setResetting(true);
+    try {
+      await resetSync();
+    } finally {
+      setResetting(false);
+    }
+  };
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
@@ -9,8 +31,15 @@ export default function NodeStatusPage() {
           Monitor the health and performance of the TWINS blockchain node
         </p>
       </div>
-      
+
       <NodeStatus />
+      <button
+        onClick={handleReset}
+        disabled={resetting}
+        className="mt-6 rounded bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+      >
+        {resetting ? 'Resetting…' : 'Reset Sync'}
+      </button>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- allow resetting the node database by wiping SQLite file and restoring genesis
- expose POST `/api/v1/reset-sync` on the Rust API
- add `reset` method to blockchain `ChainState`
- store DB path in storage and provide `reset_db`
- update Node page with a Reset Sync button

## Testing
- `npm install`
- `npm run lint`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686044c6f1f483278b610900a1a4c3db